### PR TITLE
feat : 카카오 로그인 & 로그아웃 & 연동해제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,12 +21,24 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	set('springCloudVersion', "2022.0.3")
+}
+
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	//implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/com/example/artfriendly/ArtfriendlyApplication.java
+++ b/src/main/java/com/example/artfriendly/ArtfriendlyApplication.java
@@ -2,8 +2,12 @@ package com.example.artfriendly;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.servlet.ServletComponentScan;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@ServletComponentScan
+@EnableFeignClients
 public class ArtfriendlyApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/artfriendly/client/RequestForm.java
+++ b/src/main/java/com/example/artfriendly/client/RequestForm.java
@@ -1,0 +1,54 @@
+package com.example.artfriendly.client;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@RequiredArgsConstructor
+@Component
+public class RequestForm {
+    @Value("${kakao.grantType}")
+    private String grantType;
+    @Value("${kakao.clientId}")
+    private String clientId;
+    @Value("${kakao.clientSecret}")
+    private String clientSecret;
+    @Value("${kakao.redirectUri}")
+    private String redirectUri;
+    @Value("${kakao.logout.redirectUri}")
+    private String logoutRedirectUri;
+    private String code;
+
+    public HttpEntity<MultiValueMap<String, String>>  makeRequestTokenForm(String code){
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+        return new HttpEntity<>(params, headers);
+    }
+
+    public HttpEntity<MultiValueMap<String, String>>  makeRequestLogoutForm(String accessToken){
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+        headers.add("Authorization", accessToken);
+        return new HttpEntity<>(headers);
+    }
+
+    public HttpEntity<MultiValueMap<String, String>>  makeRequestUnlinkForm(String accessToken){
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+        headers.add("Authorization", accessToken);
+        return new HttpEntity<>(headers);
+    }
+
+}

--- a/src/main/java/com/example/artfriendly/controller/AuthController.java
+++ b/src/main/java/com/example/artfriendly/controller/AuthController.java
@@ -1,0 +1,57 @@
+package com.example.artfriendly.controller;
+
+
+import com.example.artfriendly.client.RequestForm;
+import com.example.artfriendly.model.OAuthToken;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestTemplate;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+    private final RequestForm requestForm;
+    @GetMapping("/oauth/kakao")
+    public @ResponseBody String kakaoLogin(@RequestParam(name = "code") String code) throws JsonProcessingException {
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> response = rt.exchange(
+                "https://kauth.kakao.com/oauth/token", // https://{요청할 서버 주소}
+                HttpMethod.POST, // 요청할 방식
+                requestForm.makeRequestTokenForm(code), // 요청할 때 보낼 데이터
+                String.class // 요청 시 반환되는 데이터 타입
+        );
+        ObjectMapper objectMapper = new ObjectMapper();
+        OAuthToken oAuthToken = objectMapper.readValue(response.getBody(), OAuthToken.class);
+        return oAuthToken.getAccess_token();
+    }
+
+    @GetMapping("oauth/kakao/logout")
+    public @ResponseBody String kakaoLogout(@RequestHeader(name = "Authorization") String accessToken) throws JsonProcessingException {
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> response = rt.exchange(
+                "https://kapi.kakao.com/v1/user/logout",
+                HttpMethod.POST,
+                requestForm.makeRequestLogoutForm(accessToken),
+                String.class // 요청 시 반환되는 데이터 타입
+        );
+        return response.getBody(); // 로그아웃 아이디 반환됨
+    }
+
+
+    @GetMapping("oauth/kakao/unlink")
+    public @ResponseBody String kakaoUnlink(@RequestHeader(name = "Authorization") String accessToken) throws JsonProcessingException {
+        System.out.println(accessToken);
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> response = rt.exchange(
+                "https://kapi.kakao.com/v1/user/unlink",
+                HttpMethod.POST,
+                requestForm.makeRequestUnlinkForm(accessToken),
+                String.class // 요청 시 반환되는 데이터 타입
+        );
+        return response.getBody(); // 로그아웃 아이디 반환됨
+    }
+
+}

--- a/src/main/java/com/example/artfriendly/controller/HomeController.java
+++ b/src/main/java/com/example/artfriendly/controller/HomeController.java
@@ -1,0 +1,12 @@
+package com.example.artfriendly.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HomeController {
+    @GetMapping("/home")
+    public String goHome(){
+        return "home";
+    }
+}

--- a/src/main/java/com/example/artfriendly/controller/UserController.java
+++ b/src/main/java/com/example/artfriendly/controller/UserController.java
@@ -1,0 +1,7 @@
+package com.example.artfriendly.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UserController {
+}

--- a/src/main/java/com/example/artfriendly/model/OAuthToken.java
+++ b/src/main/java/com/example/artfriendly/model/OAuthToken.java
@@ -1,0 +1,14 @@
+package com.example.artfriendly.model;
+
+import lombok.Data;
+
+@Data
+public class OAuthToken {
+    private String access_token;
+    private String token_type;
+    private String refresh_token;
+    private String id_token;
+    private int expires_in;
+    private String scope;
+    private int refresh_token_expires_in;
+}

--- a/src/main/java/com/example/artfriendly/service/AuthService.java
+++ b/src/main/java/com/example/artfriendly/service/AuthService.java
@@ -1,0 +1,11 @@
+package com.example.artfriendly.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+}

--- a/src/main/java/com/example/artfriendly/service/LoginService.java
+++ b/src/main/java/com/example/artfriendly/service/LoginService.java
@@ -1,0 +1,4 @@
+package com.example.artfriendly.service;
+
+public class LoginService {
+}


### PR DESCRIPTION
# Changes 
RestTemplate을 사용하여 카카오 api 요청

## 로그인
프론트에서 인가 코드를 받음
해당 코드로 accessToken 카카오 api에 요청
accessToken, refreshToken, token_id 반환

## 로그아웃
accessToken을 파라미터로 api 요청
로그아웃 후 회원 아이디 반환

## 연동해제
accessToken을 파라미터로 api 요청
연동 해제 후 회원 아이디 반환
